### PR TITLE
Add `map` and `when` extension methods over `StockResponse`

### DIFF
--- a/lib/src/stock_response_extensions.dart
+++ b/lib/src/stock_response_extensions.dart
@@ -6,16 +6,16 @@ extension StockResponseExtensions<T> on StockResponse<T> {
   /// Invoke [onData] if the response is successful, [onLoading] if the response
   /// is loading, and [onError] if the response is an error.
   E map<E>({
+    required E Function(StockResponseLoading<T> value) onLoading,
     required E Function(StockResponseData<T> value) onData,
     required E Function(StockResponseError<T> value) onError,
-    required E Function(StockResponseLoading<T> value) onLoading,
   }) {
-    if (this is StockResponseData<T>) {
+    if (this is StockResponseLoading<T>) {
+      return onLoading(this as StockResponseLoading<T>);
+    } else if (this is StockResponseData<T>) {
       return onData(this as StockResponseData<T>);
     } else if (this is StockResponseError<T>) {
       return onError(this as StockResponseError<T>);
-    } else if (this is StockResponseLoading<T>) {
-      return onLoading(this as StockResponseLoading<T>);
     } else {
       throw StockError('Unknown StockResponse type: $this');
     }
@@ -25,50 +25,43 @@ extension StockResponseExtensions<T> on StockResponse<T> {
   /// [onLoading] or [orElse] as fallback if the response is loading, and
   /// [onError] or [orElse] as fallback if the response is an error.
   E maybeMap<E>({
+    E Function(StockResponseLoading<T> value)? onLoading,
     E Function(StockResponseData<T> value)? onData,
     E Function(StockResponseError<T> value)? onError,
-    E Function(StockResponseLoading<T> value)? onLoading,
     required E Function() orElse,
   }) =>
       map(
+        onLoading: onLoading ?? (_) => orElse(),
         onData: onData ?? (_) => orElse(),
         onError: onError ?? (_) => orElse(),
-        onLoading: onLoading ?? (_) => orElse(),
       );
 
   /// Invoke [onData] if the response is successful, [onLoading] if the response
   /// is loading, and [onError] if the response is an error.
   E when<E>({
-    required E Function(ResponseOrigin origin, T value) onData,
-    required E Function(
-      ResponseOrigin origin,
-      Object error,
-      StackTrace? stackTrace,
-    )
-        onError,
-    required E Function(ResponseOrigin origin) onLoading,
+    required E Function() onLoading,
+    required E Function(T data) onData,
+    required E Function(Object error, StackTrace? stackTrace) onError,
   }) =>
       map(
-        onData: (value) => onData(value.origin, value.value),
-        onError: (value) =>
-            onError(value.origin, value.error, value.stackTrace),
-        onLoading: (value) => onLoading(value.origin),
+        onLoading: (value) => onLoading(),
+        onData: (value) => onData(value.value),
+        onError: (value) => onError(value.error, value.stackTrace),
       );
 
   /// Invoke [onData] or [orElse] as fallback if the response is successful,
   /// [onLoading] or [orElse] as fallback if the response is loading, and
   /// [onError] or [orElse] as fallback if the response is an error.
   E maybeWhen<E>({
-    E Function(ResponseOrigin origin, T value)? onData,
-    E Function(ResponseOrigin origin, Object error, StackTrace? stackTrace)?
-        onError,
-    E Function(ResponseOrigin origin)? onLoading,
+    E Function()? onLoading,
+    E Function(T data)? onData,
+    E Function(Object error, StackTrace? stackTrace)? onError,
     required E Function() orElse,
   }) =>
       when(
-        onData: onData ?? (_, __) => orElse(),
-        onError: onError ?? (_, __, ___) => orElse(),
-        onLoading: onLoading ?? (_) => orElse(),
+        onLoading: onLoading ?? () => orElse(),
+        onData: onData ?? (_) => orElse(),
+        onError: onError ?? (_, __) => orElse(),
       );
 
   /// Returns the available data or throws error if there is no data.

--- a/lib/src/stock_response_extensions.dart
+++ b/lib/src/stock_response_extensions.dart
@@ -36,6 +36,25 @@ extension StockResponseExtensions<T> on StockResponse<T> {
         onLoading: onLoading ?? (_) => orElse(),
       );
 
+  /// Invoke [onData] if the response is successful, [onLoading] if the response
+  /// is loading, and [onError] if the response is an error.
+  E when<E>({
+    required E Function(ResponseOrigin origin, T value) onData,
+    required E Function(
+      ResponseOrigin origin,
+      Object error,
+      StackTrace? stackTrace,
+    )
+        onError,
+    required E Function(ResponseOrigin origin) onLoading,
+  }) =>
+      map(
+        onData: (value) => onData(value.origin, value.value),
+        onError: (value) =>
+            onError(value.origin, value.error, value.stackTrace),
+        onLoading: (value) => onLoading(value.origin),
+      );
+
   /// Returns the available data or throws error if there is no data.
   T requireData() {
     if (this is StockResponseData<T>) {

--- a/lib/src/stock_response_extensions.dart
+++ b/lib/src/stock_response_extensions.dart
@@ -39,29 +39,43 @@ extension StockResponseExtensions<T> on StockResponse<T> {
   /// Invoke [onData] if the response is successful, [onLoading] if the response
   /// is loading, and [onError] if the response is an error.
   E when<E>({
-    required E Function() onLoading,
-    required E Function(T data) onData,
-    required E Function(Object error, StackTrace? stackTrace) onError,
+    required E Function(ResponseOrigin origin) onLoading,
+    required E Function(ResponseOrigin origin, T data) onData,
+    required E Function(
+      ResponseOrigin origin,
+      Object error,
+      StackTrace? stackTrace,
+    )
+        onError,
   }) =>
       map(
-        onLoading: (value) => onLoading(),
-        onData: (value) => onData(value.value),
-        onError: (value) => onError(value.error, value.stackTrace),
+        onLoading: (value) => onLoading(value.origin),
+        onData: (value) => onData(value.origin, value.value),
+        onError: (value) => onError(
+          value.origin,
+          value.error,
+          value.stackTrace,
+        ),
       );
 
   /// Invoke [onData] or [orElse] as fallback if the response is successful,
   /// [onLoading] or [orElse] as fallback if the response is loading, and
   /// [onError] or [orElse] as fallback if the response is an error.
   E maybeWhen<E>({
-    E Function()? onLoading,
-    E Function(T data)? onData,
-    E Function(Object error, StackTrace? stackTrace)? onError,
-    required E Function() orElse,
+    E Function(ResponseOrigin origin)? onLoading,
+    E Function(ResponseOrigin origin, T data)? onData,
+    E Function(
+      ResponseOrigin origin,
+      Object error,
+      StackTrace? stackTrace,
+    )?
+        onError,
+    required E Function(ResponseOrigin origin) orElse,
   }) =>
       when(
-        onLoading: onLoading ?? () => orElse(),
-        onData: onData ?? (_) => orElse(),
-        onError: onError ?? (_, __) => orElse(),
+        onLoading: onLoading ?? (origin) => orElse(origin),
+        onData: onData ?? (origin, _) => orElse(origin),
+        onError: onError ?? (origin, _, __) => orElse(origin),
       );
 
   /// Returns the available data or throws error if there is no data.

--- a/lib/src/stock_response_extensions.dart
+++ b/lib/src/stock_response_extensions.dart
@@ -21,6 +21,21 @@ extension StockResponseExtensions<T> on StockResponse<T> {
     }
   }
 
+  /// Invoke [onData] or [orElse] as fallback if the response is successful,
+  /// [onLoading] or [orElse] as fallback if the response is loading, and
+  /// [onError] or [orElse] as fallback if the response is an error.
+  E maybeMap<E>({
+    E Function(StockResponseData<T> value)? onData,
+    E Function(StockResponseError<T> value)? onError,
+    E Function(StockResponseLoading<T> value)? onLoading,
+    required E Function() orElse,
+  }) =>
+      map(
+        onData: onData ?? (_) => orElse(),
+        onError: onError ?? (_) => orElse(),
+        onLoading: onLoading ?? (_) => orElse(),
+      );
+
   /// Returns the available data or throws error if there is no data.
   T requireData() {
     if (this is StockResponseData<T>) {

--- a/lib/src/stock_response_extensions.dart
+++ b/lib/src/stock_response_extensions.dart
@@ -55,6 +55,22 @@ extension StockResponseExtensions<T> on StockResponse<T> {
         onLoading: (value) => onLoading(value.origin),
       );
 
+  /// Invoke [onData] or [orElse] as fallback if the response is successful,
+  /// [onLoading] or [orElse] as fallback if the response is loading, and
+  /// [onError] or [orElse] as fallback if the response is an error.
+  E maybeWhen<E>({
+    E Function(ResponseOrigin origin, T value)? onData,
+    E Function(ResponseOrigin origin, Object error, StackTrace? stackTrace)?
+        onError,
+    E Function(ResponseOrigin origin)? onLoading,
+    required E Function() orElse,
+  }) =>
+      when(
+        onData: onData ?? (_, __) => orElse(),
+        onError: onError ?? (_, __, ___) => orElse(),
+        onLoading: onLoading ?? (_) => orElse(),
+      );
+
   /// Returns the available data or throws error if there is no data.
   T requireData() {
     if (this is StockResponseData<T>) {

--- a/lib/src/stock_response_extensions.dart
+++ b/lib/src/stock_response_extensions.dart
@@ -3,6 +3,24 @@ import 'package:stock/src/stock_response.dart';
 
 /// Useful [StockResponse] extensions.
 extension StockResponseExtensions<T> on StockResponse<T> {
+  /// Invoke [onData] if the response is successful, [onLoading] if the response
+  /// is loading, and [onError] if the response is an error.
+  E map<E>({
+    required E Function(StockResponseData<T> value) onData,
+    required E Function(StockResponseError<T> value) onError,
+    required E Function(StockResponseLoading<T> value) onLoading,
+  }) {
+    if (this is StockResponseData<T>) {
+      return onData(this as StockResponseData<T>);
+    } else if (this is StockResponseError<T>) {
+      return onError(this as StockResponseError<T>);
+    } else if (this is StockResponseLoading<T>) {
+      return onLoading(this as StockResponseLoading<T>);
+    } else {
+      throw StockError('Unknown StockResponse type: $this');
+    }
+  }
+
   /// Returns the available data or throws error if there is no data.
   T requireData() {
     if (this is StockResponseData<T>) {

--- a/test/stock_response_extension_test.dart
+++ b/test/stock_response_extension_test.dart
@@ -187,6 +187,29 @@ void main() {
       verifyNever(mockDataCallback());
       verify(mockErrorCallback()).called(1);
     });
+
+    test('Map with unknown type', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      expect(
+        () {
+          _FakeType().map(
+            onLoading: (_) => mockLoadingCallback(),
+            onData: (_) => mockDataCallback(),
+            onError: (_) => mockErrorCallback(),
+          );
+        },
+        throwsA(
+          (dynamic e) =>
+              e is StockError &&
+              e.message.startsWith('Unknown StockResponse type: '),
+        ),
+      );
+      verifyNever(mockLoadingCallback());
+      verifyNever(mockDataCallback());
+      verifyNever(mockErrorCallback());
+    });
   });
 
   group('MaybeMap', () {

--- a/test/stock_response_extension_test.dart
+++ b/test/stock_response_extension_test.dart
@@ -1,3 +1,4 @@
+import 'package:mockito/mockito.dart';
 import 'package:stock/src/errors.dart';
 import 'package:stock/src/extensions/stock_response_internal_extensions.dart';
 import 'package:stock/src/stock_response.dart';
@@ -143,7 +144,280 @@ void main() {
       );
     });
   });
+
+  group('Map', () {
+    test('Map for loading', () {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponseLoading<dynamic>(ResponseOrigin.fetcher).map(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_) => mockDataCallback(),
+        onError: (_) => mockErrorCallback(),
+      );
+      verify(mockLoadingCallback()).called(1);
+      verifyNever(mockDataCallback());
+      verifyNever(mockErrorCallback());
+    });
+
+    test('Map for data', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponse.data(ResponseOrigin.fetcher, 1).map(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_) => mockDataCallback(),
+        onError: (_) => mockErrorCallback(),
+      );
+      verifyNever(mockLoadingCallback());
+      verify(mockDataCallback()).called(1);
+      verifyNever(mockErrorCallback());
+    });
+
+    test('Map for error', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      StockResponseError<dynamic>(ResponseOrigin.fetcher, Error()).map(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_) => mockDataCallback(),
+        onError: (_) => mockErrorCallback(),
+      );
+      verifyNever(mockLoadingCallback());
+      verifyNever(mockDataCallback());
+      verify(mockErrorCallback()).called(1);
+    });
+  });
+
+  group('MaybeMap', () {
+    test('MaybeMap for loading', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponseLoading<dynamic>(ResponseOrigin.fetcher).maybeMap(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_) => mockDataCallback(),
+        onError: (_) => mockErrorCallback(),
+        orElse: () => throw Exception('Should not be called'),
+      );
+      verify(mockLoadingCallback()).called(1);
+      verifyNever(mockDataCallback());
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeMap for loading with else', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponseLoading<dynamic>(ResponseOrigin.fetcher).maybeMap(
+        onData: (_) => mockDataCallback(),
+        onError: (_) => mockErrorCallback(),
+        orElse: mockLoadingCallback,
+      );
+      verify(mockLoadingCallback()).called(1);
+      verifyNever(mockDataCallback());
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeMap for data', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponse.data(ResponseOrigin.fetcher, 1).maybeMap(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_) => mockDataCallback(),
+        onError: (_) => mockErrorCallback(),
+        orElse: () => throw Exception('Should not be called'),
+      );
+      verifyNever(mockLoadingCallback());
+      verify(mockDataCallback()).called(1);
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeMap for data with else', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponse.data(ResponseOrigin.fetcher, 1).maybeMap(
+        onLoading: (_) => mockLoadingCallback(),
+        onError: (_) => mockErrorCallback(),
+        orElse: mockDataCallback,
+      );
+      verifyNever(mockLoadingCallback());
+      verify(mockDataCallback()).called(1);
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeMap for error', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      StockResponseError<dynamic>(ResponseOrigin.fetcher, Error()).maybeMap(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_) => mockDataCallback(),
+        onError: (_) => mockErrorCallback(),
+        orElse: () => throw Exception('Should not be called'),
+      );
+      verifyNever(mockLoadingCallback());
+      verifyNever(mockDataCallback());
+      verify(mockErrorCallback()).called(1);
+    });
+
+    test('MaybeMap for error with else', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      StockResponseError<dynamic>(ResponseOrigin.fetcher, Error()).maybeMap(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_) => mockDataCallback(),
+        orElse: mockErrorCallback,
+      );
+      verifyNever(mockLoadingCallback());
+      verifyNever(mockDataCallback());
+      verify(mockErrorCallback()).called(1);
+    });
+  });
+
+  group('When', () {
+    test('When for loading', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponseLoading<dynamic>(ResponseOrigin.fetcher).when(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_, __) => mockDataCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+      );
+      verify(mockLoadingCallback()).called(1);
+      verifyNever(mockDataCallback());
+      verifyNever(mockErrorCallback());
+    });
+
+    test('When for data', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponse.data(ResponseOrigin.fetcher, 1).when(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_, __) => mockDataCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+      );
+      verifyNever(mockLoadingCallback());
+      verify(mockDataCallback()).called(1);
+      verifyNever(mockErrorCallback());
+    });
+
+    test('When for error', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      StockResponseError<dynamic>(ResponseOrigin.fetcher, Error()).when(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_, __) => mockDataCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+      );
+      verifyNever(mockLoadingCallback());
+      verifyNever(mockDataCallback());
+      verify(mockErrorCallback()).called(1);
+    });
+  });
+
+  group('MaybeWhen', () {
+    test('MaybeWhen for loading', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponseLoading<dynamic>(ResponseOrigin.fetcher).maybeWhen(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_, __) => mockDataCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+        orElse: (_) => throw Exception('Should not be called'),
+      );
+      verify(mockLoadingCallback()).called(1);
+      verifyNever(mockDataCallback());
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeWhen for loading with else', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponseLoading<dynamic>(ResponseOrigin.fetcher).maybeWhen(
+        onData: (_, __) => mockDataCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+        orElse: (_) => mockLoadingCallback(),
+      );
+      verify(mockLoadingCallback()).called(1);
+      verifyNever(mockDataCallback());
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeWhen for data', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponse.data(ResponseOrigin.fetcher, 1).maybeWhen(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_, __) => mockDataCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+        orElse: (_) => throw Exception('Should not be called'),
+      );
+      verifyNever(mockLoadingCallback());
+      verify(mockDataCallback()).called(1);
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeWhen for data with else', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      const StockResponse.data(ResponseOrigin.fetcher, 1).maybeWhen(
+        onLoading: (_) => mockLoadingCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+        orElse: (_) => mockDataCallback(),
+      );
+      verifyNever(mockLoadingCallback());
+      verify(mockDataCallback()).called(1);
+      verifyNever(mockErrorCallback());
+    });
+
+    test('MaybeWhen for error', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      StockResponseError<dynamic>(ResponseOrigin.fetcher, Error()).maybeWhen(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_, __) => mockDataCallback(),
+        onError: (_, __, ___) => mockErrorCallback(),
+        orElse: (_) => throw Exception('Should not be called'),
+      );
+      verifyNever(mockLoadingCallback());
+      verifyNever(mockDataCallback());
+      verify(mockErrorCallback()).called(1);
+    });
+
+    test('MaybeWhen for error with else', () async {
+      final mockLoadingCallback = MockCallback();
+      final mockDataCallback = MockCallback();
+      final mockErrorCallback = MockCallback();
+      StockResponseError<dynamic>(ResponseOrigin.fetcher, Error()).maybeWhen(
+        onLoading: (_) => mockLoadingCallback(),
+        onData: (_, __) => mockDataCallback(),
+        orElse: (_) => mockErrorCallback(),
+      );
+      verifyNever(mockLoadingCallback());
+      verifyNever(mockDataCallback());
+      verify(mockErrorCallback()).called(1);
+    });
+  });
 }
+
+// ignore: one_member_abstracts
+abstract class Callback {
+  void call();
+}
+
+class MockCallback extends Mock implements Callback {}
 
 class _FakeType implements StockResponse<int> {
   @override


### PR DESCRIPTION
## Description

The goal is to use the `StockResponse` in a more declarative way by using extension methods on `StockResponse`.

### Methods

- [x] `map` method
- [x] `maybeMap` method
- [x] `when` method
- [x] `maybeWhen` method

### Tests

- [x] `map` test
- [x] `maybeMap` test
- [x] `when` test
- [x] `maybeWhen` test


### Example

```dart
// Create a stream to listen tweet changes of the user `xmartlabs`
stock
    .stream('xmartlabs', refresh: true)
    .listen((StockResponse<List<Tweet>> stockResponse) {
  if (stockResponse is StockResponseLoading) {
    _displayLoadingIndicator();
  } else if (stockResponse is StockResponseData) {
    _displayTweetsInUI(stockResponse.requireData());
  } else {
    _displayErrorInUi((stockResponse as StockResponseError).error);
  }
});
```

With `when`:

```dart
// Create a stream to listen tweet changes of the user `xmartlabs`
stock
  .stream('xmartlabs', refresh: true)
  .listen((StockResponse<List<Tweet>> stockResponse) => stockResponse.when(
        onLoading: _displayLoadingIndicator,
        onData: _displayTweetsInUI,
        onError: (error, stackTrace) => _displayErrorInUi(error),
      ));
```
