### PR TITLE
fix: Avoid concurrency issue when multiple requests are made with the same key

### DIFF
--- a/.github/workflows/dart-coverage.yml
+++ b/.github/workflows/dart-coverage.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  check_coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/lib/src/implementations/stock_impl.dart
+++ b/lib/src/implementations/stock_impl.dart
@@ -1,7 +1,9 @@
 // ignore_for_file: public_member_api_docs
 
 import 'dart:async';
+import 'dart:math';
 
+import 'package:meta/meta.dart';
 import 'package:mutex/mutex.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stock/src/extensions/future_stream_internal_extensions.dart';
@@ -15,6 +17,9 @@ import 'package:stock/src/stock_request.dart';
 import 'package:stock/src/stock_response.dart';
 import 'package:stock/src/stock_response_extensions.dart';
 
+@visibleForTesting
+typedef SessionStreamKey = double;
+
 class StockImpl<Key, Output> implements Stock<Key, Output> {
   StockImpl({
     required Fetcher<Key, Output> fetcher,
@@ -25,9 +30,11 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
   final FactoryFetcher<Key, Output> _fetcher;
   final SourceOfTruth<Key, Output>? _sourceOfTruth;
 
-  final Map<Key, int> _writingMap = {};
-  final Map<Key, int> _listenerCount = {};
-  final _writingLock = Mutex();
+  @visibleForTesting
+  final Map<Key, Set<SessionStreamKey>> sessionFetcherPendingRequests = {};
+  @visibleForTesting
+  final Map<Key, Set<SessionStreamKey>> currentStreamSessions = {};
+  final _notifyPendingRequestsLock = Mutex();
 
   @override
   Future<Output> fresh(Key key) =>
@@ -71,6 +78,8 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
     StockRequest<Key> request,
     SourceOfTruth<Key, Output> sourceOfTruth,
   ) async* {
+    final sessionKey = Random.secure().nextDouble();
+
     final controller = StreamController<StockResponse<Output?>>.broadcast();
     final syncLock = Mutex();
     await syncLock.acquire();
@@ -80,6 +89,7 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
       request: request,
       sourceOfTruth: sourceOfTruth,
       emitMutex: syncLock,
+      sessionStreamKey: sessionKey,
     );
 
     final sourceOfTruthSubscription = _generateSourceOfTruthStreamSubscription(
@@ -87,15 +97,17 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
       sourceOfTruth: sourceOfTruth,
       dataStreamController: controller,
       dbLock: syncLock,
+      sessionStreamKey: sessionKey,
     );
 
     yield* controller.stream.whereDataNotNull().doOnCancel(() async {
-      _listenerCount[request.key] = _listenerCount[request.key]! - 1;
+      currentStreamSessions[request.key]?.remove(sessionKey);
       await fetcherSubscription.cancel();
       await sourceOfTruthSubscription.cancel();
     }).doOnListen(
-      () => _writingLock.protect(() async {
-        _listenerCount[request.key] = (_listenerCount[request.key] ?? 0) + 1;
+      () => _notifyPendingRequestsLock.protect(() async {
+        currentStreamSessions[request.key] =
+            (currentStreamSessions[request.key] ?? {})..add(sessionKey);
       }),
     );
   }
@@ -105,6 +117,7 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
     required SourceOfTruth<Key, Output>? sourceOfTruth,
     required Mutex emitMutex,
     required StreamController<StockResponse<Output?>> dataStreamController,
+    required SessionStreamKey sessionStreamKey,
   }) =>
       Stream.fromFuture(
         _shouldStartNetworkStream(request, dataStreamController),
@@ -119,20 +132,21 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
           .listen(
             (response) => emitMutex.protect(() async {
               if (response is StockResponseData<Output>) {
-                await _writingLock.protect(
-                  () async => _incrementWritingMap(
+                await _notifyPendingRequestsLock.protect(
+                  () async => _setupSessionPendingRequest(
                     request,
-                    _listenerCount[request.key]!,
+                    currentStreamSessions[request.key]!,
                   ),
                 );
-                // request, 1));
                 final writerResult = await sourceOfTruth
                     ?.write(request.key, response.value)
                     .mapToResponse(ResponseOrigin.fetcher);
                 if (writerResult is StockResponseError) {
                   dataStreamController.add(writerResult.swapType());
-                  await _writingLock
-                      .protect(() async => _incrementWritingMap(request, -1));
+                  await _notifyPendingRequestsLock.protect(
+                    () async => sessionFetcherPendingRequests[request.key]
+                        ?.remove(sessionStreamKey),
+                  );
                 }
               } else {
                 dataStreamController.add(response);
@@ -140,8 +154,13 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
             }),
           );
 
-  int _incrementWritingMap(StockRequest<Key> request, int increment) =>
-      _writingMap[request.key] = (_writingMap[request.key] ?? 0) + increment;
+  void _setupSessionPendingRequest(
+    StockRequest<Key> request,
+    Set<SessionStreamKey> currentSessions,
+  ) =>
+      sessionFetcherPendingRequests[request.key] =
+          (sessionFetcherPendingRequests[request.key] ?? {})
+            ..addAll(currentSessions);
 
   Stream<StockResponse<Output>> _startNetworkFlow(
     bool shouldFetchNewValue,
@@ -178,6 +197,7 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
     required SourceOfTruth<Key, Output> sourceOfTruth,
     required Mutex dbLock,
     required StreamController<StockResponse<Output?>> dataStreamController,
+    required SessionStreamKey sessionStreamKey,
   }) {
     var initialSyncDone = false;
     final sourceOfTruthSubscription = sourceOfTruth
@@ -185,13 +205,12 @@ class StockImpl<Key, Output> implements Stock<Key, Output> {
         .mapToResponse(ResponseOrigin.sourceOfTruth)
         .listen((response) async {
       if (response is StockResponseData<Output?>) {
-        final fetcherData = await _writingLock.protect(() async {
-          final writingKeyData = (_writingMap[request.key] ?? -1) > 0;
-          if (writingKeyData) {
-            _incrementWritingMap(request, -1);
-          }
-          return writingKeyData;
-        });
+        final fetcherData = await _notifyPendingRequestsLock.protect(
+          () async =>
+              sessionFetcherPendingRequests[request.key]
+                  ?.remove(sessionStreamKey) ??
+              false,
+        );
         dataStreamController.add(
           StockResponseData(
             fetcherData ? ResponseOrigin.fetcher : response.origin,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  equatable:
+    dependency: "direct dev"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   file:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,42 +5,47 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: "5aaf60d96c4cd00fe7f21594b5ad6a1b699c80a27420f8a837f4d68473ef09e3"
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "68.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.1.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "21f1d3720fd1c70316399d5e2bccaebb415c434592d778cce8acb967b8578808"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.5.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
@@ -61,34 +66,34 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "64e12b0521812d1684b1917bc80945625391cb9bdd4312536b1d69dcb6133ed8"
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "3ac61a79bfb6f6cc11f693591063a7f19a7af628dc52f141743edac5c16e8c22"
+      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.9"
+    version: "2.4.11"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: c9e32d21dd6626b5c163d48b037ce906bbe428bc23ab77bcd77bb21e593b6185
+      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.11"
+    version: "7.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -101,10 +106,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a8de5955205b4d1dbbbc267daddf2178bd737e4bab8987c04a500478c9651e74
+      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.3"
+    version: "8.9.2"
   characters:
     dependency: transitive
     description:
@@ -133,50 +138,50 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
+      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.10.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: "595a29b55ce82d53398e1bcc2cba525d7bd7c59faeb2d2540e9d42c390cfeeeb"
+      sha256: "88b0fddbe4c92910fefc09cc0248f5e7f0cd23e450ded4c28f16ab8ee8f83268"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.4"
+    version: "1.10.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.6"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.7"
   dartx:
     dependency: "direct dev"
     description:
@@ -197,26 +202,26 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -229,10 +234,10 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -245,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.1"
   io:
     dependency: transitive
     description:
@@ -261,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   lints:
     dependency: "direct dev"
     description:
@@ -285,10 +290,18 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "12e8a9842b5a7390de7a781ec63d793527582398d16ea26c60fed58833c9ae79"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-main.0"
   matcher:
     dependency: transitive
     description:
@@ -301,18 +314,18 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.6"
   mockito:
     dependency: "direct dev"
     description:
@@ -349,10 +362,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   pool:
     dependency: transitive
     description:
@@ -373,10 +386,10 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   rxdart:
     dependency: "direct main"
     description:
@@ -389,10 +402,10 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -405,34 +418,34 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
@@ -453,10 +466,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -477,10 +490,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "0bd04f5bb74fcd6ff0606a888a30e917af9bd52820b178eaa464beb11dca84b6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.0"
   term_glyph:
     dependency: transitive
     description:
@@ -493,26 +506,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: d11b55850c68c1f6c0cf00eabded4e66c4043feaf6c0d7ce4a36785137df6331
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.5"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4d070a6bc36c1c4e89f20d353bfd71dc30cdf2bd0e14349090af360a029ab292"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.5"
   time:
     dependency: transitive
     description:
@@ -549,10 +562,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: a13d5503b4facefc515c8c587ce3cf69577a7b064a9f1220e005449cf1f64aad
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -561,14 +574,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.1"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.6.3"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      sha256: "81269c8d3f45541082bfbb117bbc962cfc68b5197eb4c705a00db4ddf394e1c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -113,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -161,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  dartx:
+    dependency: "direct dev"
+    description:
+      name: dartx
+      sha256: "8b25435617027257d43e6508b5fe061012880ddfdaa75a71d607c3de2a13d244"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   equatable:
     dependency: "direct dev"
     description:
@@ -489,6 +513,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.2"
+  time:
+    dependency: transitive
+    description:
+      name: time
+      sha256: ad8e018a6c9db36cb917a031853a1aae49467a93e0d464683e029537d848c221
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   timing:
     dependency: transitive
     description:
@@ -554,4 +586,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.9
+  equatable: ^2.0.5
   lints: ^3.0.0
   mockito: ^5.4.4
   test: ^1.25.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.9
+  dartx: ^1.2.0
   equatable: ^2.0.5
   lints: ^3.0.0
   mockito: ^5.4.4

--- a/test/common/mock_key_value.dart
+++ b/test/common/mock_key_value.dart
@@ -1,0 +1,11 @@
+import 'package:equatable/equatable.dart';
+
+class MockIntKeyValue extends Equatable {
+  const MockIntKeyValue(this.key, this.value);
+
+  final int key;
+  final int value;
+
+  @override
+  List<Object> get props => [key];
+}

--- a/test/common/source_of_truth/cached_source_of_truth_with_default_value.dart
+++ b/test/common/source_of_truth/cached_source_of_truth_with_default_value.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:rxdart/rxdart.dart';
 import 'package:stock/src/source_of_truth.dart';
 

--- a/test/common/stock_test_extensions.dart
+++ b/test/common/stock_test_extensions.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:dartx/dartx.dart';
+import 'package:stock/src/implementations/stock_impl.dart';
 import 'package:stock/src/stock.dart';
 import 'package:stock/src/stock_response.dart';
 
@@ -25,6 +27,15 @@ extension StockExtensions<Key, Output> on Stock<Key, Output> {
         (value) =>
             value.map((items) => items.removeStacktraceIfNeeded()).toList(),
       );
+
+  int get currentStreamSessionCount => (this as StockImpl)
+      .currentStreamSessions
+      .entries
+      .sumBy((e) => e.value.length);
+  int get sessionFetcherPendingRequests => (this as StockImpl)
+      .sessionFetcherPendingRequests
+      .entries
+      .sumBy((e) => e.value.length);
 }
 
 class ResultListener<T> {


### PR DESCRIPTION
This pr adds a session id to track the different sessions, this is used to track the different notifications that are pending 